### PR TITLE
Remove extra RegCloseKey

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -118,7 +118,6 @@ bool userRegCheck(const std::string& regKey) {
 		DWORD type;
 		if (RegQueryValueEx(hKey, regKey.c_str(), NULL, &type, (LPBYTE)&val, &dataSize) == ERROR_SUCCESS)
 		{
-			RegCloseKey(hKey);
 			if (val != 46 || type != REG_SZ) { //Character code 46 = "."
 				badKey = true;
 			}


### PR DESCRIPTION
Remove extra RegCloseKey in userRegCheck method which causes the opened registry key to be closed twice and cause an exception.